### PR TITLE
Re-add missing systemSubscription to fix "Plugins" tab

### DIFF
--- a/ui/src/app/components/settings-menu/settings-menu.component.html
+++ b/ui/src/app/components/settings-menu/settings-menu.component.html
@@ -78,8 +78,8 @@
                 Plugins
             </ng-template>
             <div class="tab-content">
-                @if (config && system) {
-                    @if (system.edcopilot_installed) {
+                @if (config) {
+                    @if (system && system.edcopilot_installed) {
                         <mat-expansion-panel>
                             <mat-expansion-panel-header>
                                 <mat-panel-title>

--- a/ui/src/app/components/settings-menu/settings-menu.component.ts
+++ b/ui/src/app/components/settings-menu/settings-menu.component.ts
@@ -65,6 +65,7 @@ export class SettingsMenuComponent implements OnInit, OnDestroy {
     has_plugin_settings: boolean = false;
     system: SystemInfo | null = null;
     private configSubscription?: Subscription;
+    private systemSubscription?: Subscription;
     private plugin_settings_message_subscription?: Subscription;
     private validationSubscription?: Subscription;
     public usageDisclaimerAccepted = false;
@@ -91,6 +92,17 @@ export class SettingsMenuComponent implements OnInit, OnDestroy {
                 this.config = config;
             },
         );
+        this.systemSubscription = this.configService.system$
+            .subscribe(
+                (system) => {
+                this.system = system;
+                if (system) {
+                    console.log("System info loaded");
+                } else {
+                    console.error("Received null system info");
+                }
+                },
+            );
         this.plugin_settings_message_subscription = this.configService
             .plugin_settings_message$
             .subscribe(
@@ -98,7 +110,7 @@ export class SettingsMenuComponent implements OnInit, OnDestroy {
                     this.has_plugin_settings =
                         plugin_settings_message?.has_plugin_settings || false;
                     if (plugin_settings_message?.plugin_settings_configs) {
-                        console.log("Plugin settings count received", {
+                        console.log("Receieved has_plugin_settings", {
                             has_plugin_settings:
                                 plugin_settings_message.has_plugin_settings,
                         });
@@ -128,6 +140,9 @@ export class SettingsMenuComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         if (this.configSubscription) {
             this.configSubscription.unsubscribe();
+        }
+        if (this.systemSubscription) {
+            this.systemSubscription.unsubscribe();
         }
         if (this.validationSubscription) {
             this.validationSubscription.unsubscribe();


### PR DESCRIPTION
Re-added missing systemSubscription after refactor, to fix broken "Plugins" tab.

Also corrected an old console.log() statement of mine.